### PR TITLE
Slice into channels from axis definition, if possible

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Development server
 
 .. code-block:: console
 
-    $ panel serve src/image_viewer/app.py --port 9123 --autoreload
+    $ panel serve src/image_viewer/app.py --port 9123 --dev
 
 Notes
 -----

--- a/src/image_viewer/app.py
+++ b/src/image_viewer/app.py
@@ -1,3 +1,5 @@
+from __futures__ import annotations
+
 import numpy as np
 import panel as pn
 

--- a/src/image_viewer/app.py
+++ b/src/image_viewer/app.py
@@ -42,6 +42,7 @@ def viewer():
     figure = ApertureFigure.new(
         array,
         title=meta.get('title', None),
+        channel_dimension=meta.get('channel_dimension', -1),
     )
     return pn.Column(
         header_md,

--- a/src/image_viewer/components.py
+++ b/src/image_viewer/components.py
@@ -1,3 +1,5 @@
+from __futures__ import annotations
+
 import pathlib
 import importlib
 import urllib.parse
@@ -51,7 +53,10 @@ def load_rsciio(path: pathlib.Path):
     return result['data'], result['axes']
 
 
-def channel_dim_from_axes(axes: list[dict]):
+def channel_dim_from_axes(axes: list[dict] | None):
+    # axes is None if we used skimage to load the array
+    if axes is None:
+        return -1
     return tuple(
         axis['index_in_array']
         for axis in axes


### PR DESCRIPTION
Fixes #3

~~Creates a list of array slices into the loaded data, either taking a `slice(None, None, None)` for sig dims, or popping a concrete index from a `ndindex` iteration for nav dims. Of course not suitable for huge arrays, but still works okay on my laptop for a `((20, 3838, 3710)` test stack (that's about 1.1GB)~~

sets `channel_dimension` to a tuple of all navigation axes.